### PR TITLE
Rubygems is HTTPS now

### DIFF
--- a/lib/rubygems/browse/command.rb
+++ b/lib/rubygems/browse/command.rb
@@ -35,7 +35,7 @@ module Gem::Browse
     def get_json(name)
       require 'open-uri'
       begin
-        open("http://rubygems.org/api/v1/gems/#{name}.json").read
+        open("https://rubygems.org/api/v1/gems/#{name}.json").read
       rescue OpenURI::HTTPError
         alert_error "Cannot retrieve gem information for #{name} from rubygems.org."
         terminate_interaction 1

--- a/lib/rubygems/commands/browse_command.rb
+++ b/lib/rubygems/commands/browse_command.rb
@@ -14,7 +14,7 @@ class Gem::Commands::BrowseCommand < Gem::Browse::Command
       rescue Gem::LoadError
         get_json(name)[/"homepage_uri":\s*"([^"]*)"/, 1]
       end
-    homepage = "http://rubygems.org/gems/#{name}" if homepage.to_s.empty?
+    homepage = "https://rubygems.org/gems/#{name}" if homepage.to_s.empty?
     unless system('git', 'web--browse', homepage)
       alert_error('Error starting web browser (using git web--browse).')
       terminate_interaction 1


### PR DESCRIPTION
I get this lovely message:

    $ gem clone bundler
    ERROR:  While executing gem ... (RuntimeError)
        redirection forbidden: http://rubygems.org/api/v1/gems/bundler.json -> https://rubygems.org/api/v1/gems/bundler.json

This seems to solve the issue.