### PR TITLE
Prefer Uri.open over Kernel#open

### DIFF
--- a/gem-browse.gemspec
+++ b/gem-browse.gemspec
@@ -21,5 +21,5 @@ gem browse: open a gem's homepage in your browser.
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency('rake', '~> 0.8')
+  s.add_development_dependency('rake', '~> 13.0.1')
 end

--- a/lib/rubygems/browse/command.rb
+++ b/lib/rubygems/browse/command.rb
@@ -35,7 +35,7 @@ module Gem::Browse
     def get_json(name)
       require 'open-uri'
       begin
-        open("https://rubygems.org/api/v1/gems/#{name}.json").read
+        URI.open("https://rubygems.org/api/v1/gems/#{name}.json").read
       rescue OpenURI::HTTPError
         alert_error "Cannot retrieve gem information for #{name} from rubygems.org."
         terminate_interaction 1


### PR DESCRIPTION
Calling URI.open via Kernel#open is deprecated.